### PR TITLE
fix for "only `win32` is supported" on windows

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-if (process.platform !== 'win32') {
+if (process.platform != 'win32') {
   // not windows
   console.warn('only `win32` is supported. Perhaps you should look for `cross-sqlcipher`.')
   process.exit(1)


### PR DESCRIPTION
I tried npm install win-sqlcipher but it gave an error "only `win32` is supported. Perhaps you should look for `cross-sqlcipher`.". I tested process.version and it did return 'win32' so looked into the install script and noticed it was using double == in the process version test. Changing to != allows my machine to compile the module out of the box.